### PR TITLE
Fallback to `_internalModel.modelName` if `constructor.modelName` is undefined

### DIFF
--- a/addon/mixins/store.js
+++ b/addon/mixins/store.js
@@ -37,8 +37,9 @@ const StoreMixin = Ember.Mixin.create({
 
     resArray.forEach(res => {
       if (res && (id = res.get('id'))) {
-        const type = this.modelFor(res.constructor.modelName);
-        const adapter = this.adapterFor(res.constructor.modelName);
+        const modelName = res.get('constructor.modelName') || res._internalModel.modelName;
+        const type = this.modelFor(modelName);
+        const adapter = this.adapterFor(modelName);
         if (adapter instanceof SailsSocketAdapter) {
           adapter._scheduleSubscribe(type, id);
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-data-sailsjs",
-  "version": "0.0.24",
-  "description": "The default blueprint for ember-cli addons.",
+  "version": "0.0.25",
+  "description": "Adapters and tools for Ember to work well with Sails.js",
   "keywords": [
     "ember-addon"
   ],
@@ -18,35 +18,35 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-ajax": "^2.4.1",
-    "ember-cli": "2.11.1",
-    "ember-cli-app-version": "^2.0.0",
-    "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-ajax": "^3.0.0",
+    "ember-cli": "~2.17.1",
+    "ember-cli-app-version": "^3.0.0",
+    "ember-cli-dependency-checker": "^2.0.0",
+    "ember-cli-htmlbars": "^2.0.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",
-    "ember-cli-qunit": "^3.0.1",
+    "ember-cli-qunit": "^4.1.1",
     "ember-cli-release": "^0.2.9",
-    "ember-cli-shims": "^1.0.2",
+    "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.11.0",
+    "ember-data": "^2.16.2",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.6.0",
-    "ember-resolver": "^2.0.3",
-    "ember-source": "~2.11.0",
+    "ember-load-initializers": "^1.0.0",
+    "ember-resolver": "^4.0.0",
+    "ember-source": "~2.16.2",
     "ember-welcome-page": "^2.0.2",
-    "loader.js": "^4.0.10"
+    "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": ">= 0.12.0"
+    "node": ">= 6.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bc-ember-data-sails",
-  "version": "0.0.23",
+  "name": "ember-data-sailsjs",
+  "version": "0.0.24",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -11,7 +11,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "https://github.com/brickclick/ember-data-sails",
+  "repository": "https://github.com/gutschik/ember-data-sails",
   "scripts": {
     "build": "ember build",
     "start": "ember server",


### PR DESCRIPTION
had an issue with ember-data@2.16 where `constructor.modelName` was undefined when an array was pushed manually to the store. this fixes it